### PR TITLE
QF: wrong information in pal links

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -257,7 +257,9 @@ p:not(
 
 p:has(em),
 li>p,
-p.text
+p.text,
+p.tagline,
+p.details
 {
     text-indent: 0 !important;
 }

--- a/zhCN/guide/links.md
+++ b/zhCN/guide/links.md
@@ -8,7 +8,7 @@
     <a class="bitter exlink" target="_blank" href="https://learn.microsoft.com/" title="微软官方文档">Microsoft Learn*</a>
     <a class="bitter exlink" target="_blank" href="https://skripthub.net/" title="第三方Skript文档">Skript Hub*</a>
     <a class="bitter exlink" target="_blank" href="https://yizhan.wiki/NitWikit/" title="笨蛋 MC 开服教程">NitWikit</a>
-    <a class="bitter exlink" target="_blank" href="https://github.com/SnowCutieOwO/Continue" title="SnowCutie 插件文档翻译合集 《Continue》">SnowCutie【续】</a>
+    <a class="bitter exlink" target="_blank" href="https://snowcutieowo.github.io/" title="SnowCutie 插件文档翻译合集 《Continue》">【续】维基档案馆</a>
 </div>
 
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the CSS styles in `custom.css` and modifying the links in the `zhCN/guide/links.md` file for better presentation and accuracy.

### Detailed summary
- In `.vitepress/theme/custom.css`, the `text-indent` property is set to `0 !important` for specific elements.
- In `zhCN/guide/links.md`, the link for `SnowCutie` has been changed from a GitHub URL to a new wiki URL, with updated link text.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->