### PR TITLE
Update linux.md

### DIFF
--- a/zhCN/lxguide/startup/perOsSetup/linux.md
+++ b/zhCN/lxguide/startup/perOsSetup/linux.md
@@ -27,6 +27,14 @@
 
 有关于JRE的选择，参见:   [配置内存和GC、JavaAgent](/zhCN/lxguide/others/adjust-ram-gc-ja)
 
+## 输入法设置
+
+当前稳定版本由于在X11下运行需要在环境变量添加`export XMODIFIERS=@im=fcitx/ibus`来使得输入法可以使用。
+
+未来版本会迁移到Wayland下，需要在.desktop文件中添加参数`--enable-features=UseOzonePlatform --ozone-platform=wayland --enable-wayland-ime `。
+
+具体请参考Archwiki或者对应的Distro的wiki。
+
 ## 如果您无法启动
 
 您需要尝试做出以下操作：


### PR DESCRIPTION
Adding something for InputMethod

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new section to the `linux.md` documentation regarding input method settings for the current stable version and future versions, providing guidance on necessary environment variables and parameters for proper functionality.

### Detailed summary
- Added a new section titled `输入法设置` (Input Method Settings).
- Explained the need to set the environment variable `export XMODIFIERS=@im=fcitx/ibus` for input method functionality in the current stable version under X11.
- Mentioned future migration to Wayland and the need for parameters `--enable-features=UseOzonePlatform --ozone-platform=wayland --enable-wayland-ime` in the `.desktop` file.
- Suggested referring to Archwiki or the corresponding Distro's wiki for more details.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->